### PR TITLE
doctest: specify ‘opening-delimiter’ so doctests are detected and run

### DIFF
--- a/.config
+++ b/.config
@@ -1,3 +1,4 @@
 author-name = Aldwin Vlasblom
+opening-delimiter = ```js
 repo-owner = Avaq
 repo-name = permissionary

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.nyc_output/
 /coverage/
 /examples/node_modules/
 /node_modules/


### PR DESCRIPTION
Merging #9 inadvertently disabled the doctests.

This pull request is one of two possible fixes. The other option is to replace occurrences of `` ```js `` in __index.js__ with `` ```javascript ``, allowing us to use the default `opening-delimiter` value.

If you would prefer to stick with `` ```js ``, Aldwin, you're welcome to merge this pull request. If you would prefer to avoid another __.config__ entry, close this pull request and I will open a new one.
