### PR TITLE
doctest: add missing ‘> ’ prefix

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ var hasProp = Object.prototype.hasOwnProperty;
 //.
 //. // Alice, however, does. She has all permissions (even the ones
 //. // we haven't thought of yet).
-//. canAlice ('users.create')
+//. > canAlice ('users.create')
 //. true
 //. ```
 function checkPermission(grants, roles, permission) {


### PR DESCRIPTION
Now that doctests are being detected again (#10), this change has an observable effect: `npm run doctest` outputs `....` rather than `...`.
