### PR TITLE
sanctuary-scripts@^3.1.0

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,14 +7,9 @@
   "overrides": [
     {
       "files": ["*.md"],
-      "plugins": ["markdown"],
-      "env": {"es6": true},
       "globals": {"checkPermission": false, "findRoles": false},
       "rules": {
-        "strict": ["off"],
-        "no-extra-semi": ["off"],
-        "semi-style": ["off"],
-        "semi": ["off"]
+        "no-unused-vars": ["error", {"varsIgnorePattern": "^(checkPermission|findRoles)$"}]
       }
     }
   ]

--- a/index.js
+++ b/index.js
@@ -15,7 +15,6 @@
 //.
 //. ## Usage
 //.
-//. <!-- eslint-disable no-unused-vars -->
 //. ```js
 //. var {checkPermission, findRoles} = require ('permissionary');
 //. ```

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   },
   "devDependencies": {
     "codecov": "^3.0.0",
-    "sanctuary-scripts": "^3.0.0"
+    "sanctuary-scripts": "^3.1.0"
   }
 }


### PR DESCRIPTION
Once released, `sanctuary-scripts@3.1.0` will address sanctuary-js/sanctuary-scripts#14.

I am opening this pull request, which currently depends on an unreleased commit, to demonstrate that the `lint-readme` changes in the forthcoming sanctuary-scripts pull request have the intended effect.
